### PR TITLE
fix/reset-state-on-destroy

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -339,7 +339,7 @@ const Pull = {
 
         // Enable setupEvents to run again
         _setup = false;
-        // resets state when module is loaded again
+        // resets _state on destory - will be useful when the element is destroyed while refresh is inprogress.
         _state = 'pending';
 
         // null object references

--- a/src/index.js
+++ b/src/index.js
@@ -339,6 +339,8 @@ const Pull = {
 
         // Enable setupEvents to run again
         _setup = false;
+        // resets state when module is loaded again
+        _state = 'pending';
 
         // null object references
         handlers = null;


### PR DESCRIPTION
Currently the _state variable is not reset on destroy. So if the user navigates away from the screen and comeback again in Single Page Application, the old state value is retained which prevents the user from pulling. Resetting the _state allows it to be pulled.